### PR TITLE
Abstract weather data fetching logic to a WeatherDataProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import HistogramPage from "./pages/HistogramPage";
 import AnimatedHistogram from "./pages/AnimatedHistogram";
 import AnimatedLineChart from "./pages/AnimatedLineChart";
 
+import WeatherDataProvider from "./components/WeatherDataProvider";
+
 function App() {
   return (
     <>
@@ -16,12 +18,27 @@ function App() {
           <Route path="/">
             <Route index element={<MainPage />} />
             <Route path="chapters">
-              <Route path="making-your-first-chart" element={<LineChart />} />
-              <Route path="making-a-scatterplot" element={<ScatterPlot />} />
-              <Route path="making-a-bar-chart" element={<HistogramPage />} />
+              <Route
+                path="making-your-first-chart"
+                element={<WeatherDataProvider Consumer={LineChart} />}
+              />
+              <Route
+                path="making-a-scatterplot"
+                element={<WeatherDataProvider Consumer={ScatterPlot} />}
+              />
+              <Route
+                path="making-a-bar-chart"
+                element={<WeatherDataProvider Consumer={HistogramPage} />}
+              />
               <Route path="animations-and-transitions">
-                <Route path="histogram" element={<AnimatedHistogram />} />
-                <Route path="line" element={<AnimatedLineChart />} />
+                <Route
+                  path="histogram"
+                  element={<WeatherDataProvider Consumer={AnimatedHistogram} />}
+                />
+                <Route
+                  path="line"
+                  element={<WeatherDataProvider Consumer={AnimatedLineChart} />}
+                />
               </Route>
             </Route>
           </Route>

--- a/src/components/WeatherDataProvider.tsx
+++ b/src/components/WeatherDataProvider.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+import { useWeatherData } from "../hooks/useWeatherData";
+
+import type { WeatherData } from "../hooks/useWeatherData";
+
+function WeatherDataProvider({
+  Consumer,
+}: {
+  Consumer: React.FC<{ dataset: WeatherData[] }>;
+}) {
+  //* Step 1a. Fetch Data
+  const { dataset, status, error } = useWeatherData();
+
+  switch (status) {
+    case "idle":
+      return <span>Waiting for data...</span>;
+    case "pending":
+      return <div>Loading data...</div>;
+    case "rejected":
+      throw error;
+    case "resolved":
+      return <Consumer dataset={dataset as WeatherData[]} />;
+  }
+}
+
+export default WeatherDataProvider;

--- a/src/pages/AnimatedHistogram.tsx
+++ b/src/pages/AnimatedHistogram.tsx
@@ -5,8 +5,6 @@ import { animated, Transition, Spring } from "@react-spring/web";
 import Chart from "../components/Chart";
 import Axis from "../components/Axis";
 
-import { useWeatherData } from "../hooks/useWeatherData";
-
 import type { WeatherData } from "../hooks/useWeatherData";
 import type { BoundedDimensions } from "../utils/types";
 
@@ -53,9 +51,7 @@ const metrics: NumberDataMetric[] = [
   "temperatureMax",
 ];
 
-function AnimatedHistogram() {
-  //* Step 1a. Fetch Data
-  const { dataset, status, error } = useWeatherData();
+function AnimatedHistogram({ dataset }: { dataset: WeatherData[] }) {
   const [selectedMetricIndex, setSelectedMetricIndex] = React.useState(0);
 
   const metric = metrics[selectedMetricIndex];
@@ -63,195 +59,182 @@ function AnimatedHistogram() {
   function changeMetric() {
     setSelectedMetricIndex((selectedMetricIndex + 1) % metrics.length);
   }
+  //* Step 1b. Access Data
+  const xAccessor = (d: WeatherData) => d[metric];
+  const yAccessor = (bin: WeatherDataBin) => bin.length;
 
-  switch (status) {
-    case "idle":
-      return <span>Waiting for data...</span>;
-    case "pending":
-      return <div>Loading data...</div>;
-    case "rejected":
-      throw error;
-    case "resolved": {
-      //* Step 1b. Access Data
-      const xAccessor = (d: WeatherData) => d[metric];
-      const yAccessor = (bin: WeatherDataBin) => bin.length;
+  //* Step 4. Create scales
+  const xScale = d3
+    .scaleLinear()
+    .domain(d3.extent(dataset, xAccessor) as [number, number])
+    .range([0, dimensions.boundedWidth])
+    .nice();
 
-      //* Step 4. Create scales
-      const xScale = d3
-        .scaleLinear()
-        .domain(
-          d3.extent(dataset as WeatherData[], xAccessor) as [number, number]
-        )
-        .range([0, dimensions.boundedWidth])
-        .nice();
+  const binsGenerator = d3
+    .bin<WeatherData, number>()
+    .domain(xScale.domain() as [number, number])
+    .value(xAccessor)
+    .thresholds(12);
 
-      const binsGenerator = d3
-        .bin<WeatherData, number>()
-        .domain(xScale.domain() as [number, number])
-        .value(xAccessor)
-        .thresholds(12);
+  const bins = binsGenerator(dataset);
 
-      const bins = binsGenerator(dataset as WeatherData[]);
+  const yScale = d3
+    .scaleLinear()
+    //? For histograms, we want the y axis to always start at 0
+    .domain([0, d3.max(bins, yAccessor)] as [0, number])
+    .range([dimensions.boundedHeight, 0])
+    .nice();
 
-      const yScale = d3
-        .scaleLinear()
-        //? For histograms, we want the y axis to always start at 0
-        .domain([0, d3.max(bins, yAccessor)] as [0, number])
-        .range([dimensions.boundedHeight, 0])
-        .nice();
+  const barPadding = 1;
+  const xAccessorScaled = (d: WeatherDataBin) =>
+    xScale(d.x0 as number) + barPadding;
+  const yAccessorScaled = (bin: WeatherDataBin) => yScale(yAccessor(bin));
 
-      const barPadding = 1;
-      const xAccessorScaled = (d: WeatherDataBin) =>
-        xScale(d.x0 as number) + barPadding;
-      const yAccessorScaled = (bin: WeatherDataBin) => yScale(yAccessor(bin));
+  //! React handles updates differently than d3.transition().
+  //! As such, changing metrics causes values to be calculated
+  //! with the latest scale/accessor functions during rendering.
+  //! This causes the bars to get a lot wider/thinner when switching
+  //! between metrics that have different scales.
+  const widthAccessorScaled = (d: WeatherDataBin) =>
+    xScale(d.x1 as number) - xScale(d.x0 as number) - barPadding;
+  const heightAccessorScaled = (d: WeatherDataBin) =>
+    dimensions.boundedHeight - yScale(yAccessor(d));
 
-      //! React handles updates differently than d3.transition().
-      //! As such, changing metrics causes values to be calculated
-      //! with the latest scale/accessor functions during rendering.
-      //! This causes the bars to get a lot wider/thinner when switching
-      //! between metrics that have different scales.
-      const widthAccessorScaled = (d: WeatherDataBin) =>
-        xScale(d.x1 as number) - xScale(d.x0 as number) - barPadding;
-      const heightAccessorScaled = (d: WeatherDataBin) =>
-        dimensions.boundedHeight - yScale(yAccessor(d));
+  const midpointAccessorScaled = (d: WeatherDataBin) =>
+    xScale(d.x0 as number) +
+    (xScale(d.x1 as number) - xScale(d.x0 as number)) / 2;
 
-      const midpointAccessorScaled = (d: WeatherDataBin) =>
-        xScale(d.x0 as number) +
-        (xScale(d.x1 as number) - xScale(d.x0 as number)) / 2;
+  const mean = d3.mean(dataset, xAccessor) as number;
 
-      const mean = d3.mean(dataset as WeatherData[], xAccessor) as number;
-
-      return (
-        <div className={styles.container}>
-          {/* Add a div to copy the structure from the original example */}
-          <div>
-            {/* Step 3. Draw canvas */}
-            <Chart dimensions={dimensions}>
-              {/* Step 5. Draw data */}
-              <g
-                role="list"
-                tabIndex={0}
-                aria-label="histogram bars"
-                clipPath="url(#bounds-clip-path)"
-              >
-                <Transition
-                  items={bins}
-                  from={(bin) => ({
-                    barY: dimensions.boundedHeight,
-                    barWidth: Math.max(0, widthAccessorScaled(bin)),
-                    barHeight: 0,
-                    textY: dimensions.boundedHeight + 5,
-                    textOpacity: 0,
-                    fill: "#63fd58",
-                  })}
-                  enter={(bin) => [
-                    {
-                      barY: dimensions.boundedHeight,
-                      barWidth: Math.max(0, widthAccessorScaled(bin)),
-                      barHeight: 0,
-                      textY: dimensions.boundedHeight + 5,
-                      fill: "#63fd58",
-                    },
-                    {
-                      barY: yAccessorScaled(bin),
-                      barHeight: heightAccessorScaled(bin),
-                      textY: yAccessorScaled(bin) - 5,
-                      textOpacity: 1,
-                    },
-                    { fill: "#588dfd" },
-                  ]}
-                  leave={{
-                    fill: "#fd5869",
-                    textOpacity: 0,
-                    barY: dimensions.boundedHeight,
-                    barHeight: 0,
-                    textY: dimensions.boundedHeight + 5,
-                  }}
-                  exitBeforeEnter={true}
-                >
-                  {(
-                    { barY, barWidth, barHeight, textY, textOpacity, fill },
-                    bin
-                  ) => {
-                    return (
-                      <g
-                        role="listitem"
-                        tabIndex={0}
-                        aria-label={`There were ${yAccessor(
-                          bin
-                        )} days with ${metric} between ${bin.x0} and ${bin.x1}`}
-                      >
-                        <animated.rect
-                          x={xAccessorScaled(bin)}
-                          // width={Math.max(0, widthAccessorScaled(bin))}
-                          style={{
-                            y: barY,
-                            width: barWidth,
-                            height: barHeight,
-                            fill,
-                          }}
-                        />
-                        <animated.text
-                          x={midpointAccessorScaled(bin)}
-                          textAnchor="middle"
-                          fill="hsl(0deg 0% 40%)"
-                          fontSize="12px"
-                          style={{
-                            y: textY,
-                            opacity: textOpacity,
-                          }}
-                        >
-                          {yAccessor(bin)}
-                        </animated.text>
-                      </g>
-                    );
-                  }}
-                </Transition>
-              </g>
-              {/* Step 6. Draw peripherals */}
-              <Spring to={{ x: xScale(mean) }} delay={700}>
-                {({ x }) => (
-                  <>
-                    <animated.line
-                      x1={x}
-                      x2={x}
-                      y1={-15}
-                      y2={dimensions.boundedHeight}
-                      className={styles.mean}
-                      stroke="maroon"
-                      strokeDasharray="2px 4px"
+  return (
+    <div className={styles.container}>
+      {/* Add a div to copy the structure from the original example */}
+      <div>
+        {/* Step 3. Draw canvas */}
+        <Chart dimensions={dimensions}>
+          {/* Step 5. Draw data */}
+          <g
+            role="list"
+            tabIndex={0}
+            aria-label="histogram bars"
+            clipPath="url(#bounds-clip-path)"
+          >
+            <Transition
+              items={bins}
+              from={(bin) => ({
+                barY: dimensions.boundedHeight,
+                barWidth: Math.max(0, widthAccessorScaled(bin)),
+                barHeight: 0,
+                textY: dimensions.boundedHeight + 5,
+                textOpacity: 0,
+                fill: "#63fd58",
+              })}
+              enter={(bin) => [
+                {
+                  barY: dimensions.boundedHeight,
+                  barWidth: Math.max(0, widthAccessorScaled(bin)),
+                  barHeight: 0,
+                  textY: dimensions.boundedHeight + 5,
+                  fill: "#63fd58",
+                },
+                {
+                  barY: yAccessorScaled(bin),
+                  barHeight: heightAccessorScaled(bin),
+                  textY: yAccessorScaled(bin) - 5,
+                  textOpacity: 1,
+                },
+                { fill: "#588dfd" },
+              ]}
+              leave={{
+                fill: "#fd5869",
+                textOpacity: 0,
+                barY: dimensions.boundedHeight,
+                barHeight: 0,
+                textY: dimensions.boundedHeight + 5,
+              }}
+              exitBeforeEnter={true}
+            >
+              {(
+                { barY, barWidth, barHeight, textY, textOpacity, fill },
+                bin
+              ) => {
+                return (
+                  <g
+                    role="listitem"
+                    tabIndex={0}
+                    aria-label={`There were ${yAccessor(
+                      bin
+                    )} days with ${metric} between ${bin.x0} and ${bin.x1}`}
+                  >
+                    <animated.rect
+                      x={xAccessorScaled(bin)}
+                      // width={Math.max(0, widthAccessorScaled(bin))}
+                      style={{
+                        y: barY,
+                        width: barWidth,
+                        height: barHeight,
+                        fill,
+                      }}
                     />
                     <animated.text
-                      role="presentation"
-                      aria-hidden={true}
-                      x={x}
-                      y={-20}
+                      x={midpointAccessorScaled(bin)}
                       textAnchor="middle"
-                      fill="maroon"
+                      fill="hsl(0deg 0% 40%)"
                       fontSize="12px"
+                      style={{
+                        y: textY,
+                        opacity: textOpacity,
+                      }}
                     >
-                      mean
+                      {yAccessor(bin)}
                     </animated.text>
-                  </>
-                )}
-              </Spring>
-              <Axis dimension="x" scale={xScale} label={metric} />
-              <clipPath id="bounds-clip-path">
-                <rect
-                  width={dimensions.boundedWidth}
-                  height={dimensions.boundedHeight + dimensions.margin.top}
-                  y={-dimensions.margin.top}
+                  </g>
+                );
+              }}
+            </Transition>
+          </g>
+          {/* Step 6. Draw peripherals */}
+          <Spring to={{ x: xScale(mean) }} delay={700}>
+            {({ x }) => (
+              <>
+                <animated.line
+                  x1={x}
+                  x2={x}
+                  y1={-15}
+                  y2={dimensions.boundedHeight}
+                  className={styles.mean}
+                  stroke="maroon"
+                  strokeDasharray="2px 4px"
                 />
-              </clipPath>
-            </Chart>
-          </div>
-          <button className={styles.btn} onClick={changeMetric}>
-            Change metric
-          </button>
-        </div>
-      );
-    }
-  }
+                <animated.text
+                  role="presentation"
+                  aria-hidden={true}
+                  x={x}
+                  y={-20}
+                  textAnchor="middle"
+                  fill="maroon"
+                  fontSize="12px"
+                >
+                  mean
+                </animated.text>
+              </>
+            )}
+          </Spring>
+          <Axis dimension="x" scale={xScale} label={metric} />
+          <clipPath id="bounds-clip-path">
+            <rect
+              width={dimensions.boundedWidth}
+              height={dimensions.boundedHeight + dimensions.margin.top}
+              y={-dimensions.margin.top}
+            />
+          </clipPath>
+        </Chart>
+      </div>
+      <button className={styles.btn} onClick={changeMetric}>
+        Change metric
+      </button>
+    </div>
+  );
 }
 
 export default AnimatedHistogram;

--- a/src/pages/AnimatedLineChart.tsx
+++ b/src/pages/AnimatedLineChart.tsx
@@ -6,7 +6,6 @@ import Chart from "../components/Chart";
 import AnimatedLine from "../components/AnimatedLine";
 import Axis from "../components/Axis";
 
-import { useWeatherData } from "../hooks/useWeatherData";
 import { useInterval } from "../hooks/useInterval";
 
 import type { BoundedDimensions } from "../utils/types";
@@ -39,12 +38,10 @@ dimensions.boundedHeight =
 
 const formatTimelineDate = d3.timeFormat("%b %d");
 
-function AnimatedLineChart() {
-  //* Step 1a. Fetch Data
-  const { dataset, status, error } = useWeatherData();
+function AnimatedLineChart({ dataset }: { dataset: WeatherData[] }) {
   const [sliceExtent, setSliceExtent] = React.useState({ from: 0, to: 100 });
 
-  const datasetSlice = dataset?.slice(sliceExtent.from, sliceExtent.to);
+  const datasetSlice = dataset.slice(sliceExtent.from, sliceExtent.to);
 
   useInterval(() => {
     setSliceExtent((prevState) => ({
@@ -53,79 +50,71 @@ function AnimatedLineChart() {
     }));
   }, 1000);
 
-  switch (status) {
-    case "idle":
-      return <span>Submit a pokemon</span>;
-    case "pending":
-      return <div>Loading...</div>;
-    case "rejected":
-      throw error;
-    case "resolved": {
-      //* Step 4. Create scales
-      const xScale = d3
-        .scaleTime()
-        .domain(
-          d3.extent(datasetSlice as WeatherData[], xAccessor) as [Date, Date]
-        )
-        .range([0, dimensions.boundedWidth]);
+  //* Step 4. Create scales
+  const xScale = d3
+    .scaleTime()
+    .domain(d3.extent(datasetSlice, xAccessor) as [Date, Date])
+    .range([0, dimensions.boundedWidth]);
 
-      const yScale = d3
-        .scaleLinear()
-        .domain(
-          d3.extent(dataset as WeatherData[], yAccessor) as [number, number]
-        )
-        .range([dimensions.boundedHeight, 0]);
+  const yScale = d3
+    .scaleLinear()
+    .domain(d3.extent(dataset, yAccessor) as [number, number])
+    .range([dimensions.boundedHeight, 0]);
 
-      const xAccessorScaled = (d: WeatherData) => xScale(xAccessor(d));
-      const yAccessorScaled = (d: WeatherData) => yScale(yAccessor(d));
+  const xAccessorScaled = (d: WeatherData) => xScale(xAccessor(d));
+  const yAccessorScaled = (d: WeatherData) => yScale(yAccessor(d));
+  // const y0AccessorScaled = () => yScale(yScale.domain()[0]);
 
-      const freezingTemperaturePlacement = yScale(32);
+  const freezingTemperaturePlacement = yScale(32);
 
-      const lastTwoPoints = (datasetSlice as WeatherData[]).slice(-2);
-      const pixelsBetweenLastPoints =
-        xScale(xAccessor(lastTwoPoints[1])) -
-        xScale(xAccessor(lastTwoPoints[0]));
+  const lastTwoPoints = datasetSlice.slice(-2);
+  const pixelsBetweenLastPoints =
+    xScale(xAccessor(lastTwoPoints[1])) - xScale(xAccessor(lastTwoPoints[0]));
 
-      return (
-        <div>
-          {/* Step 3. Draw canvas */}
-          <Chart dimensions={dimensions}>
-            <rect
-              x="0"
-              width={dimensions.boundedWidth}
-              y={freezingTemperaturePlacement}
-              height={dimensions.boundedHeight - freezingTemperaturePlacement}
-              fill="hsl(180deg 44% 92%)"
-            />
-            {/* Step 5. Draw data */}
-            <Spring
-              //? Re-render the line when the datasetSlice updates
-              //? to imitate our original output with vanilla D3
-              key={`${sliceExtent.from}-${sliceExtent.to}`}
-              from={{ transform: `translateX(${pixelsBetweenLastPoints}px)` }}
-              to={{ transform: "translateX(0px)" }}
-            >
-              {(springStyles) => (
-                <AnimatedLine
-                  data={datasetSlice as WeatherData[]}
-                  xAccessor={xAccessorScaled}
-                  yAccessor={yAccessorScaled}
-                  style={springStyles}
-                />
-              )}
-            </Spring>
-            {/* Step 6. Draw peripherals */}
-            <Axis
-              dimension="x"
-              scale={xScale}
-              formatTick={formatTimelineDate}
-            />
-            <Axis dimension="y" scale={yScale} />
-          </Chart>
-        </div>
-      );
-    }
-  }
+  return (
+    <div>
+      {/* Step 3. Draw canvas */}
+      <Chart dimensions={dimensions}>
+        <rect
+          x="0"
+          width={dimensions.boundedWidth}
+          y={freezingTemperaturePlacement}
+          height={dimensions.boundedHeight - freezingTemperaturePlacement}
+          fill="hsl(180deg 44% 92%)"
+        />
+        {/* Step 5. Draw data */}
+        <Spring
+          //? Re-render the line when the datasetSlice updates
+          //? to imitate our original output with vanilla D3
+          key={`${sliceExtent.from}-${sliceExtent.to}`}
+          from={{ transform: `translateX(${pixelsBetweenLastPoints}px)` }}
+          to={{ transform: "translateX(0px)" }}
+        >
+          {(springStyles) => (
+            <>
+              <AnimatedLine
+                data={datasetSlice}
+                xAccessor={xAccessorScaled}
+                yAccessor={yAccessorScaled}
+                style={springStyles}
+              />
+              {/* <AnimatedLine
+                type="area"
+                data={datasetSlice}
+                xAccessor={xAccessorScaled}
+                yAccessor={yAccessorScaled}
+                y0Accessor={y0AccessorScaled}
+                style={{ ...springStyles, fill: "hsl(41deg 35% 52% / 0.185)" }}
+              /> */}
+            </>
+          )}
+        </Spring>
+        {/* Step 6. Draw peripherals */}
+        <Axis dimension="x" scale={xScale} formatTick={formatTimelineDate} />
+        <Axis dimension="y" scale={yScale} />
+      </Chart>
+    </div>
+  );
 }
 
 export default AnimatedLineChart;

--- a/src/pages/HistogramPage.tsx
+++ b/src/pages/HistogramPage.tsx
@@ -4,8 +4,6 @@ import * as d3 from "d3";
 import Chart from "../components/Chart";
 import Axis from "../components/Axis";
 
-import { useWeatherData } from "../hooks/useWeatherData";
-
 import type { WeatherData } from "../hooks/useWeatherData";
 import type { BoundedDimensions } from "../utils/types";
 
@@ -159,33 +157,17 @@ function SingleHistogram({
   );
 }
 
-function HistogramPage() {
-  //* Step 1a. Fetch Data
-  const { dataset, status, error } = useWeatherData();
-
-  switch (status) {
-    case "idle":
-      return <span>Waiting for data...</span>;
-    case "pending":
-      return <div>Loading data...</div>;
-    case "rejected":
-      throw error;
-    case "resolved":
-      return (
-        <div className={styles.wrapper}>
-          {/* Add a div to copy the structure from the original example */}
-          <div>
-            {metrics.map((metric) => (
-              <SingleHistogram
-                key={metric}
-                dataset={dataset as WeatherData[]}
-                metric={metric}
-              />
-            ))}
-          </div>
-        </div>
-      );
-  }
+function HistogramPage({ dataset }: { dataset: WeatherData[] }) {
+  return (
+    <div className={styles.wrapper}>
+      {/* Add a div to copy the structure from the original example */}
+      <div>
+        {metrics.map((metric) => (
+          <SingleHistogram key={metric} dataset={dataset} metric={metric} />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default HistogramPage;

--- a/src/pages/LineChart.tsx
+++ b/src/pages/LineChart.tsx
@@ -5,8 +5,6 @@ import Chart from "../components/Chart";
 import Line from "../components/Line";
 import Axis from "../components/Axis";
 
-import { useWeatherData } from "../hooks/useWeatherData";
-
 import type { BoundedDimensions } from "../utils/types";
 
 import type { WeatherData } from "../hooks/useWeatherData";
@@ -37,78 +35,59 @@ dimensions.boundedHeight =
 
 const formatTimelineDate = d3.timeFormat("%B");
 
-function LineChart() {
-  //* Step 1a. Fetch Data
-  const { dataset, status, error } = useWeatherData();
+function LineChart({ dataset }: { dataset: WeatherData[] }) {
+  //* Step 4. Create scales
+  const xScale = d3
+    .scaleTime()
+    .domain(d3.extent(dataset, xAccessor) as [Date, Date])
+    .range([0, dimensions.boundedWidth]);
 
-  switch (status) {
-    case "idle":
-      return <span>Submit a pokemon</span>;
-    case "pending":
-      return <div>Loading...</div>;
-    case "rejected":
-      throw error;
-    case "resolved": {
-      //* Step 4. Create scales
-      const xScale = d3
-        .scaleTime()
-        .domain(d3.extent(dataset as WeatherData[], xAccessor) as [Date, Date])
-        .range([0, dimensions.boundedWidth]);
+  const yScale = d3
+    .scaleLinear()
+    .domain(d3.extent(dataset, yAccessor) as [number, number])
+    .range([dimensions.boundedHeight, 0]);
 
-      const yScale = d3
-        .scaleLinear()
-        .domain(
-          d3.extent(dataset as WeatherData[], yAccessor) as [number, number]
-        )
-        .range([dimensions.boundedHeight, 0]);
+  const xAccessorScaled = (d: WeatherData) => xScale(xAccessor(d));
+  const yAccessorScaled = (d: WeatherData) => yScale(yAccessor(d));
+  // const y0AccessorScaled = () => yScale(yScale.domain()[0]);
 
-      const xAccessorScaled = (d: WeatherData) => xScale(xAccessor(d));
-      const yAccessorScaled = (d: WeatherData) => yScale(yAccessor(d));
-      // const y0AccessorScaled = () => yScale(yScale.domain()[0]);
+  const freezingTemperaturePlacement = yScale(32);
 
-      const freezingTemperaturePlacement = yScale(32);
-
-      //* Notice how React lets us draw everything we need for the charts
-      //* in such a nice, declarative way
-      //* We can also abstract common steps in separate reusable components
-      //* to make our workflow a lot easier!
-      return (
-        <div>
-          {/* Step 3. Draw canvas */}
-          <Chart dimensions={dimensions}>
-            <rect
-              x="0"
-              width={dimensions.boundedWidth}
-              y={freezingTemperaturePlacement}
-              height={dimensions.boundedHeight - freezingTemperaturePlacement}
-              fill="hsl(180deg 44% 92%)"
-            />
-            {/* Step 5. Draw data */}
-            <Line
-              data={dataset as WeatherData[]}
-              xAccessor={xAccessorScaled}
-              yAccessor={yAccessorScaled}
-            />
-            {/* <Line
-              type="area"
-              data={dataset as WeatherData[]}
-              xAccessor={xAccessorScaled}
-              yAccessor={yAccessorScaled}
-              y0Accessor={y0AccessorScaled}
-              style={{ fill: "hsl(41deg 35% 52% / 0.185)" }}
-            /> */}
-            {/* Step 6. Draw peripherals */}
-            <Axis
-              dimension="x"
-              scale={xScale}
-              formatTick={formatTimelineDate}
-            />
-            <Axis dimension="y" scale={yScale} />
-          </Chart>
-        </div>
-      );
-    }
-  }
+  //* Notice how React lets us draw everything we need for the charts
+  //* in such a nice, declarative way
+  //* We can also abstract common steps in separate reusable components
+  //* to make our workflow a lot easier!
+  return (
+    <div>
+      {/* Step 3. Draw canvas */}
+      <Chart dimensions={dimensions}>
+        <rect
+          x="0"
+          width={dimensions.boundedWidth}
+          y={freezingTemperaturePlacement}
+          height={dimensions.boundedHeight - freezingTemperaturePlacement}
+          fill="hsl(180deg 44% 92%)"
+        />
+        {/* Step 5. Draw data */}
+        <Line
+          data={dataset}
+          xAccessor={xAccessorScaled}
+          yAccessor={yAccessorScaled}
+        />
+        {/* <Line
+          type="area"
+          data={dataset}
+          xAccessor={xAccessorScaled}
+          yAccessor={yAccessorScaled}
+          y0Accessor={y0AccessorScaled}
+          style={{ fill: "hsl(41deg 35% 52% / 0.185)" }}
+        /> */}
+        {/* Step 6. Draw peripherals */}
+        <Axis dimension="x" scale={xScale} formatTick={formatTimelineDate} />
+        <Axis dimension="y" scale={yScale} />
+      </Chart>
+    </div>
+  );
 }
 
 export default LineChart;

--- a/src/pages/ScatterPlot.tsx
+++ b/src/pages/ScatterPlot.tsx
@@ -4,8 +4,6 @@ import * as d3 from "d3";
 import Chart from "../components/Chart";
 import Axis from "../components/Axis";
 
-import { useWeatherData } from "../hooks/useWeatherData";
-
 import type { BoundedDimensions } from "../utils/types";
 
 import type { WeatherData } from "../hooks/useWeatherData";
@@ -42,77 +40,57 @@ dimensions.boundedHeight =
 
 const formatTick = d3.format(".1f");
 
-function ScatterPlot() {
-  //* Step 1a. Fetch Data
-  const { dataset, status, error } = useWeatherData();
+function ScatterPlot({ dataset }: { dataset: WeatherData[] }) {
+  //* Step 4. Create scales
+  const xScale = d3
+    .scaleTime()
+    .domain(d3.extent(dataset, xAccessor) as [number, number])
+    .range([0, dimensions.boundedWidth])
+    .nice();
 
-  switch (status) {
-    case "idle":
-      return <span>Waiting for data...</span>;
-    case "pending":
-      return <div>Loading data...</div>;
-    case "rejected":
-      throw error;
-    case "resolved": {
-      //* Step 4. Create scales
-      const xScale = d3
-        .scaleTime()
-        .domain(
-          d3.extent(dataset as WeatherData[], xAccessor) as [number, number]
-        )
-        .range([0, dimensions.boundedWidth])
-        .nice();
+  const yScale = d3
+    .scaleLinear()
+    .domain(d3.extent(dataset, yAccessor) as [number, number])
+    .range([dimensions.boundedHeight, 0])
+    .nice();
 
-      const yScale = d3
-        .scaleLinear()
-        .domain(
-          d3.extent(dataset as WeatherData[], yAccessor) as [number, number]
-        )
-        .range([dimensions.boundedHeight, 0])
-        .nice();
+  const colorScale = d3
+    //? We need string types for the color range values
+    .scaleLinear<string>()
+    .domain(d3.extent(dataset, colorAccessor) as [number, number])
+    .range(["skyblue", "darkslategrey"]);
 
-      const colorScale = d3
-        //? We need string types for the color range values
-        .scaleLinear<string>()
-        .domain(
-          d3.extent(dataset as WeatherData[], colorAccessor) as [number, number]
-        )
-        .range(["skyblue", "darkslategrey"]);
+  const xAccessorScaled = (d: WeatherData) => xScale(xAccessor(d));
+  const yAccessorScaled = (d: WeatherData) => yScale(yAccessor(d));
+  const colorAccessorScaled = (d: WeatherData) => colorScale(colorAccessor(d));
 
-      const xAccessorScaled = (d: WeatherData) => xScale(xAccessor(d));
-      const yAccessorScaled = (d: WeatherData) => yScale(yAccessor(d));
-      const colorAccessorScaled = (d: WeatherData) =>
-        colorScale(colorAccessor(d));
-
-      return (
-        <div className={styles.wrapper}>
-          {/* Step 3. Draw canvas */}
-          <Chart dimensions={dimensions}>
-            {/* Step 5. Draw data */}
-            {dataset?.map((data, idx) => (
-              <circle
-                key={idx}
-                cx={xAccessorScaled(data)}
-                cy={yAccessorScaled(data)}
-                // fill="cornflowerblue"
-                fill={colorAccessorScaled(data)}
-                r={5}
-              />
-            ))}
-            {/* Step 6. Draw peripherals */}
-            <Axis dimension="x" scale={xScale} label="Dew point (&deg;F)" />
-            <Axis
-              dimension="y"
-              scale={yScale}
-              numberOfTicks={4}
-              formatTick={formatTick}
-              label="Relative Humidity"
-            />
-          </Chart>
-        </div>
-      );
-    }
-  }
+  return (
+    <div className={styles.wrapper}>
+      {/* Step 3. Draw canvas */}
+      <Chart dimensions={dimensions}>
+        {/* Step 5. Draw data */}
+        {dataset?.map((data, idx) => (
+          <circle
+            key={idx}
+            cx={xAccessorScaled(data)}
+            cy={yAccessorScaled(data)}
+            // fill="cornflowerblue"
+            fill={colorAccessorScaled(data)}
+            r={5}
+          />
+        ))}
+        {/* Step 6. Draw peripherals */}
+        <Axis dimension="x" scale={xScale} label="Dew point (&deg;F)" />
+        <Axis
+          dimension="y"
+          scale={yScale}
+          numberOfTicks={4}
+          formatTick={formatTick}
+          label="Relative Humidity"
+        />
+      </Chart>
+    </div>
+  );
 }
 
 export default ScatterPlot;


### PR DESCRIPTION
Resolves #2 .

- Charts now accept a `dataset` prop, which are passed from the WeatherDataProvider.
- WeatherDataProvider accepts a `Consumer` component as a prop, where it will pass down the `dataset` prop to, e.g.: `<WeatherDataProvider Consumer={SomeChart} />`